### PR TITLE
feat: Add build workflows for Android, Linux, and Windows applications to create release through github actions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -35,7 +35,7 @@ jobs:
           echo "storePassword=${{ secrets.KEY_STORE_PASSWORD }}" > android/key.properties
           echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
           echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
-          echo "storeFile=../key.jks" >> android/key.properties
+          echo "storeFile=key.jks" >> android/key.properties
 
       - name: Decode keystore
         run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > android/key.jks

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,60 @@
+name: Android APK Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Create key.properties file
+        run: |
+          echo "storePassword=${{ secrets.KEY_STORE_PASSWORD }}" > android/key.properties
+          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
+          echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
+          echo "storeFile=../key.jks" >> android/key.properties
+
+      - name: Decode keystore
+        run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > android/key.jks
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/app/outputs/flutter-apk/app-release.apk
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,58 @@
+name: Linux Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Linux Application
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.27.4'
+          channel: 'stable'
+          cache: true
+
+      - name: Enable Linux desktop
+        run: flutter config --enable-linux-desktop
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Linux
+        run: flutter build linux --release
+
+      - name: Create tarball
+        run: |
+          cd build/linux/x64/release/bundle
+          tar -czf ../../../../../flutter_linux_app.tar.gz .
+
+      - name: Upload Linux app
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-release
+          path: flutter_linux_app.tar.gz
+          if-no-files-found: error
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: flutter_linux_app.tar.gz
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,53 @@
+name: Windows Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Windows Application
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.27.4'
+          channel: 'stable'
+          cache: true
+
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Install dependencies
+        run: flutter pub get
+      
+      - name: Build Windows
+        run: flutter build windows --release
+      
+      - name: Create ZIP archive
+        run: |
+          cd build\windows\runner\Release
+          Compress-Archive -Path * -DestinationPath ..\..\..\..\flutter_windows_app.zip
+
+      - name: Upload Windows app
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-release
+          path: flutter_windows_app.zip
+          if-no-files-found: error
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: flutter_windows_app.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Android keystore files
+*.jks
+*.keystore
+key.properties
+keystore_base64.txt
+*.base64

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "com.example.silent_cache"
     compileSdk = flutter.compileSdkVersion
@@ -30,11 +36,20 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for building and releasing Android, Linux, and Windows applications, as well as updates to the Android build configuration to support release signing. The most important changes include the addition of workflows for different platforms and the configuration of signing properties in the Android build script.

### New GitHub Actions workflows:

* [`.github/workflows/android-build.yml`](diffhunk://#diff-49b2d9cefb8c056411b766cd738211a9ec2c54615fb3e69d4c7b529d7f7cc268R1-R60): Added a workflow to build and release an Android APK, including steps for setting up Java and Flutter, installing dependencies, creating signing files, and uploading the APK.
* [`.github/workflows/linux-build.yml`](diffhunk://#diff-f7f5582d7c4b2247b94182251a37bbbe432dbf3d552ab7a17841c68e29a348d6R1-R58): Added a workflow to build and release a Linux application, including steps for installing dependencies, setting up Flutter, building the application, creating a tarball, and uploading the release.
* [`.github/workflows/windows-build.yml`](diffhunk://#diff-006d566e109ce80a80cbd243c89a25b876792c89e18c2fb931eaba8535e4ed00R1-R53): Added a workflow to build and release a Windows application, including steps for setting up Flutter, enabling Windows desktop support, building the application, creating a ZIP archive, and uploading the release.

closes #2 